### PR TITLE
🎫 Rewrite `tooltip` with lower CPU usage

### DIFF
--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -139,11 +139,13 @@ timer {
     user-select: none;
 }
 
-timer.small {
+timer.small,
+timer[data-style = "small"] {
 	font-size: 17px;
 }
 
-timer.big {
+timer.big,
+timer[data-style = "big"] {
 	font-size: 34px;
 }
 
@@ -183,11 +185,13 @@ timer > days {
     font-size: 25px;
 }
 
-timer.small > days {
+timer.small > days,
+timer[data-style = "small"] > days {
 	font-size: 21px;
 }
 
-timer.big > days {
+timer.big > days,
+timer[data-style = "big"] > days {
 	font-size: 42px;
 }
 
@@ -195,11 +199,13 @@ timer > ms {
     font-size: 16px;
 }
 
-timer.small > ms {
+timer.small > ms,
+timer[data-style = "small"] > ms {
 	font-size: 13px;
 }
 
-timer.big > ms {
+timer.big > ms,
+timer[data-style = "big"] > ms {
 	font-size: 19px;
 }
 

--- a/assets/css/input.css
+++ b/assets/css/input.css
@@ -564,6 +564,7 @@ body.dark ::-webkit-calendar-picker-indicator {
 .sq-selector {
     position: relative;
     display: inline-block;
+    overflow: visible;
 
     --background: rgb(242, 242, 242);
     --active: var(--osc-color-blue);
@@ -641,10 +642,16 @@ body.dark ::-webkit-calendar-picker-indicator {
     transition: height 0.3s cubic-bezier(0.25, 1, 0.5, 1);
 }
 
+.sq-selector.fixed > .select {
+    position: absolute;
+    z-index: 1;
+}
+
 .sq-selector > .select > .list {
     display: inline-block;
     width: 100%;
-    height: auto;
+    height: 100%;
+    overflow: hidden;
 }
 
 .sq-selector > .select > .list > .item {

--- a/assets/js/belibrary.js
+++ b/assets/js/belibrary.js
@@ -3045,14 +3045,61 @@ const __connection__ = {
 
 }
 
+const mouseCursor = {
+	/**
+	 * X Position of Mouse cursor in the screen
+	 * @type {Number}
+	 */
+	x: 0,
+
+	/**
+	 * Y Position of Mouse cursor in the screen
+	 * @type {Number}
+	 */
+	y: 0,
+
+	/**
+	 * The change amount in X coordinates between current position
+	 * and last position
+	 * @type {Number}
+	 */
+	deltaX: 0,
+
+	/**
+	 * The change amount in Y coordinates between current position
+	 * and last position
+	 * @type {Number}
+	 */
+	deltaY: 0,
+
+	/**
+	 * Current element under the cursor
+	 * @type {HTMLElement}
+	 */
+	target: null,
+
+	/**
+	 * Update Function
+	 * @param {MouseEvent} event 
+	 */
+	update(event) {
+		this.x = event.clientX;
+		this.y = event.clientY;
+		this.deltaX = event.movementX;
+		this.deltaY = event.movementY;
+	}
+}
+
 //? =================
 //?    SCRIPT INIT
 
 if (typeof document.__onclog === "undefined")
 	document.__onclog = (lv, t, m) => {}
 
+window.addEventListener("mousemove", (e) => mouseCursor.update(e), { passive: true });
+
 let sc = new StopClock();
-clog("info", "Log started at:", {
+clog("INFO", "Log started at:", {
 	color: flatc("green"),
 	text: (new Date()).toString()
 })

--- a/assets/js/belibrary.js
+++ b/assets/js/belibrary.js
@@ -700,12 +700,19 @@ function parseTime(t = 0, {
 	msDigit = 3,
 	showPlus = false,
 	strVal = true,
+	calcDays = false
 } = {}) {
 	let d = showPlus ? "+" : "";
+	let days = 0;
 	
 	if (t < 0) {
 		t = -t;
 		d = "-";
+	}
+
+	if (calcDays) {
+		days = Math.floor(t / 86400);
+		t %= 86400;
 	}
 	
 	let h = Math.floor(t / 3600);
@@ -715,6 +722,7 @@ function parseTime(t = 0, {
 
 	return {
 		h, m, s, ms, d,
+		days,
 		str: (strVal)
 			? d + [h, m, s]
 				.map(v => v < 10 ? "0" + v : v)
@@ -2590,6 +2598,51 @@ function createNote({
 
 			if (message)
 				inner.innerHTML = message;
+		}
+	}
+}
+
+/**
+ * Create Timer Element
+ * @param	{Number|Object}	time	Time in seconds or object from parseTime()
+ */
+function createTimer(time = 0, {
+	style = "normal"
+} = {}) {
+	let timer = document.createElement("timer");
+	timer.dataset.style = style;
+
+	let days = document.createElement("days");
+	let inner = document.createElement("span");
+	let ms = document.createElement("ms");
+
+	timer.append(days, inner, ms);
+
+	const set = ({
+		time,
+		style
+	}) => {
+		if (typeof time === "number")
+			time = parseTime(time);
+
+		if (typeof time === "object") {
+			days.innerText = (time.days != 0) ? `${time.d}${time.days}` : "";
+			inner.innerText = time.str;
+			ms.innerText = time.ms;
+		}
+
+		if (typeof style === "string")
+			timer.dataset.style = style;
+	}
+
+	set({ time, style });
+
+	return {
+		group: timer,
+		set,
+
+		toggleMs: (show) => {
+			ms.style.display = (show) ? null : "none";
 		}
 	}
 }

--- a/assets/js/scrollable.js
+++ b/assets/js/scrollable.js
@@ -118,11 +118,11 @@ class Scrollable {
 			if (!this.scrollout && !this.smooth) {
 				let delta = event.deltaY;
 	
-				let from = (horizontal)
+				let from = (this.horizontal)
 					? this.content.scrollLeft
 					: this.content.scrollTop;
 	
-				let maxScroll = (horizontal)
+				let maxScroll = (this.horizontal)
 					? this.content.scrollWidth - this.content.offsetWidth
 					: this.content.scrollHeight - this.content.offsetHeight;
 	
@@ -407,9 +407,7 @@ class Scrollable {
 		// Amount of scroll in pixel
 		let delta;
 		if (event)
-			delta = (horizontal)
-				? event.deltaX
-				: event.deltaY;
+			delta = event.deltaY;
 		else
 			delta = value - from;
 		
@@ -442,9 +440,7 @@ class Scrollable {
 		// Amount of scroll in pixel
 		let delta;
 		if (event)
-			delta = (horizontal)
-				? event.deltaX
-				: event.deltaY;
+			delta = event.deltaY;
 		else
 			delta = value - from;
 		

--- a/assets/js/tooltip.js
+++ b/assets/js/tooltip.js
@@ -181,10 +181,8 @@ const tooltip = {
 	attachEvent(target) {
 		// Check for hook that match current target
 		for (let hook of this.hooks) {
-			if (!this.getValue(target, hook)) {
-				clog("DEBG", `tooltip.attachEvent(${hook.on} ${hook.key}): invalid target`, target);
+			if (!this.getValue(target, hook))
 				continue;
-			}
 
 			if (target.dataset.tooltipListening) {
 				clog("DEBG", `tooltip.attachEvent(${hook.on} ${hook.key}): target already listening`, target);

--- a/assets/js/tooltip.js
+++ b/assets/js/tooltip.js
@@ -228,6 +228,7 @@ const tooltip = {
 	},
 
 	__mouseMove: (e) => tooltip.mouseMove(e),
+	__mouseLeave: () => tooltip.hide(),
 
 	/**
 	 * Show the tooltip on node
@@ -240,9 +241,17 @@ const tooltip = {
 	async show(data, showOnNode, noPadding = false) {
 		if (!this.initialized)
 			return false;
+
+		if (this.nodeToShow)
+			this.nodeToShow.removeEventListener("mouseleave", this.__mouseLeave);
 		
-		if (showOnNode && showOnNode.style)
+		if (showOnNode && showOnNode.tagName) {
 			this.nodeToShow = showOnNode;
+			this.nodeToShow.addEventListener("mouseleave", this.__mouseLeave);
+		}
+
+		clearTimeout(this.hideTimeout);
+		this.hideTimeout = null;
 		
 		if (!this.showing) {
 			window.addEventListener("mousemove", this.__mouseMove, { passive: true });
@@ -253,8 +262,6 @@ const tooltip = {
 			await nextFrameAsync();
 		}
 
-		clearTimeout(this.hideTimeout);
-		this.hideTimeout = null;
 		this.container.classList.remove("hide");
 		this.showing = true;
 
@@ -299,6 +306,9 @@ const tooltip = {
 	async hide() {
 		if (!this.hideTimeout)
 			this.hideTimeout = setTimeout(() => {
+				if (this.nodeToShow)
+					this.nodeToShow.removeEventListener("mouseleave", this.__mouseLeave);
+
 				this.nodeToShow = null;
 				this.prevData = null;
 				this.container.classList.remove("show");

--- a/static/js/core.js
+++ b/static/js/core.js
@@ -2172,6 +2172,7 @@ const twi = {
 			set({ p: 0, d: `Setting Up Timer Component` });
 			this.container = document.createElement("span");
 			this.container.classList.add("component", "timer");
+			this.navTimer = createTimer(0, { style: "small" });
 
 			let icon = document.createElement("icon");
 			icon.dataset.icon = "clock";
@@ -2180,7 +2181,7 @@ const twi = {
 			progressBar.classList.add("progressBar");
 			progressBar.appendChild(this.navProgress);
 
-			this.container.append(icon, this.navTimer, progressBar);
+			this.container.append(icon, this.navTimer.group, progressBar);
 
 			this.tooltip = new navbar.Tooltip(this.container, {
 				title: "timer",
@@ -2260,7 +2261,7 @@ const twi = {
 		} = {}) {
 			if (typeof time === "number") {
 				let t = parseTime(time);
-				this.navTimer.innerHTML = `${t.str}${this.showMs ? `<ms>${t.ms}</ms>` : ""}`;
+				this.navTimer.set({ time: t });
 				
 				if (this.window.showing) {
 					if (t.h > 0) { 

--- a/static/js/core.js
+++ b/static/js/core.js
@@ -2144,9 +2144,9 @@ const twi = {
 		enabled: false,
 
 		container: HTMLElement.prototype,
-		navTimer: htmlToElement(`<timer class="small"><days>--</days>+--:--:--</timer>`),
 		navProgress: htmlToElement(`<span class="bar"></span>`),
 		tooltip: navbar.Tooltip.prototype,
+		navTimer: null,
 
 		timeData: {},
 		timeout: null,

--- a/static/js/core.js
+++ b/static/js/core.js
@@ -4570,7 +4570,7 @@ const twi = {
 
 			tooltip.addHook({
 				on: "dataset",
-				key: "rankingCell",
+				key: "ranking-cell",
 				handler: ({ target, value }) => {
 					let v = value.split("|");
 					let id = v[0],


### PR DESCRIPTION
This pull request contains rewritten code of `tooltip` with other small bug fixes in the progress. Tooltip now use event-based approach to show the tooltip on a certain element instead of scanning and tracing element currently under cursor, which greatly decrease the CPU usage when moving the mouse rapidly.